### PR TITLE
Bumped minor version, should have done this with DateTime release.

### DIFF
--- a/datetime.js
+++ b/datetime.js
@@ -39,25 +39,31 @@ var DateTime = function () {
 
 
 	/**
-  *  @var string timeZone
+  *  @var string locale
   */
 
 
 	/**
-  *  @var Date startOfMonth
+  *  @var Date endOfMonth
   */
 
 
 	/**
-  *  @var Date startOfDay
+  *  @var Date endOfDay
+  */
+
+
+	/**
+  *  @var Date dateTime
   */
 	function DateTime(dateTime) {
 		var autoResolveDefaultOptions = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : true;
 		(0, _classCallCheck3.default)(this, DateTime);
 		this.timeZone = 'Europe/Stockholm';
 		this.locale = 'en-US';
+		this.weekStartsAtIndex = 1;
 
-		this.setDateTime(dateTime);
+		this.fromDate(dateTime);
 
 		if (autoResolveDefaultOptions === true) {
 			// @FLOWFIXME https://github.com/facebook/flow/issues/2801
@@ -78,22 +84,22 @@ var DateTime = function () {
 
 
 	/**
-  *  @var string locale
+  *	@var number weekStartsAtIndex
   */
 
 
 	/**
-  *  @var Date endOfMonth
+  *  @var string timeZone
   */
 
 
 	/**
-  *  @var Date endOfDay
+  *  @var Date startOfMonth
   */
 
 
 	/**
-  *  @var Date dateTime
+  *  @var Date startOfDay
   */
 
 
@@ -147,8 +153,8 @@ var DateTime = function () {
    */
 
 	}, {
-		key: 'setDateTime',
-		value: function setDateTime() {
+		key: 'fromDate',
+		value: function fromDate() {
 			var dateTime = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null;
 
 			if (!dateTime) {
@@ -170,8 +176,8 @@ var DateTime = function () {
    */
 
 	}, {
-		key: 'getDateTime',
-		value: function getDateTime() {
+		key: 'toDate',
+		value: function toDate() {
 			return this.dateTime;
 		}
 
@@ -658,27 +664,17 @@ var DateTime = function () {
    */
 
 	}, {
-		key: 'isToday',
-		value: function isToday(dateTime) {
-			dateTime = new DateTime(dateTime).setTime(12, 0, 0, 0).getDateTime();
+		key: 'getCalendar',
 
-			var today = new Date();
-			today.setHours(12, 0, 0, 0);
-
-			return +today === +dateTime;
-		}
 
 		/**
    *	Returns an array of {@see CalendarDateType}
    *
    *	@return array
    */
-
-	}, {
-		key: 'getCalendar',
 		value: function getCalendar() {
 			var calendar = [];
-			var weekStartsAt = 1;
+			var weekStartsAt = this.weekStartsAtIndex;
 			var daysInPreviousMonth = (7 + this.startOfMonth.getDay() - weekStartsAt) % 7;
 			var calendarWeeks = Math.ceil((this.daysInMonth + daysInPreviousMonth) / 7);
 			var currentDay = 1 - daysInPreviousMonth;
@@ -698,7 +694,7 @@ var DateTime = function () {
 
 					weekDays.push({
 						dateTime: date,
-						isToday: this.isToday(date.getDateTime()),
+						isToday: DateTime.isToday(date.toDate()),
 						sameMonth: _sameMonth
 					});
 				}
@@ -790,6 +786,16 @@ var DateTime = function () {
 		key: 'daysInMonth',
 		get: function get() {
 			return this.getDaysInMonth(this.dateTime.getMonth());
+		}
+	}], [{
+		key: 'isToday',
+		value: function isToday(dateTime) {
+			dateTime = new DateTime(dateTime).setTime(12, 0, 0, 0).toDate();
+
+			var today = new Date();
+			today.setHours(12, 0, 0, 0);
+
+			return +today === +dateTime;
 		}
 	}]);
 	return DateTime;

--- a/docs/index.html
+++ b/docs/index.html
@@ -211,7 +211,7 @@
 	</g>
 </svg>
 
-				<h1>JavaScript Toolkit <var>0.1.25</var></h1>
+				<h1>JavaScript Toolkit <var>0.2.1</var></h1>
 				<h3>Common utility functions for modern JavaScript development.</h3>
 				<p>
 					<a href="https://github.com/360player/js-toolkit.git/zipball/master">Download .zip</a>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"name": "js-toolkit",
-	"version": "0.1.25",
+	"version": "0.2.1",
 	"description": "Common utility functions for modern JavaScript development.",
 	"main": "./src/index.js",
 	"author": "Robin Grass <robin@360player.com>",

--- a/spec/datetime.spec.js
+++ b/spec/datetime.spec.js
@@ -22,14 +22,14 @@ describe('initial date time values', () => {
 		const date = new Date();
 		const dateTime = new DateTime();
 
-		expect( dateTime.isToday( date) ).toBe( true );
+		expect( DateTime.isToday( date ) ).toBe( true );
 	});
 
 	it('sets initial date', () => {
 		const date = new Date( PAST_DATE );
 		const dateTime = new DateTime( date );
 
-		expect( dateTime.getDateTime() ).toEqual( date );
+		expect( dateTime.toDate() ).toEqual( date );
 	});
 
 	it('expects a year to be leap year', () => {

--- a/src/datetime.js
+++ b/src/datetime.js
@@ -52,12 +52,17 @@ export default class DateTime {
 	/**
 	 *  @var string timeZone
 	 */
-	timeZone = 'Europe/Stockholm';
+	timeZone : string = 'Europe/Stockholm';
 
 	/**
 	 *  @var string locale
 	 */
-	locale = 'en-US';
+	locale : string = 'en-US';
+
+	/**
+	 *	@var number weekStartsAtIndex
+	 */
+	weekStartsAtIndex : number = 1;
 
 	/**
 	 *  Creates a new DateTime instance.
@@ -68,7 +73,7 @@ export default class DateTime {
 	 *  @return void
 	 */
 	constructor( dateTime : Date , autoResolveDefaultOptions : boolean = true ) {
-		this.setDateTime( dateTime );
+		this.fromDate( dateTime );
 
 		if ( autoResolveDefaultOptions === true ) {
 			// @FLOWFIXME https://github.com/facebook/flow/issues/2801
@@ -127,7 +132,7 @@ export default class DateTime {
 	 *
 	 *  @return void
 	 */
-	setDateTime( dateTime : ?Date = null ) {
+	fromDate( dateTime : ?Date = null ) {
 		if ( ! dateTime ) {
 			dateTime = new Date();
 		}
@@ -145,7 +150,7 @@ export default class DateTime {
 	 *
 	 *  @return Date
 	 */
-	getDateTime() : Date {
+	toDate() : Date {
 		return this.dateTime;
 	}
 
@@ -555,8 +560,8 @@ export default class DateTime {
 	 *
 	 *	@return boolean
 	 */
-	isToday( dateTime : Date ) : boolean {
-		dateTime = ( new DateTime(dateTime) ).setTime( 12, 0, 0, 0 ).getDateTime();
+	static isToday( dateTime : Date ) : boolean {
+		dateTime = ( new DateTime(dateTime) ).setTime( 12, 0, 0, 0 ).toDate();
 
 		const today : Date = new Date();
 		today.setHours( 12, 0, 0, 0 );
@@ -571,7 +576,7 @@ export default class DateTime {
 	 */
 	getCalendar() : Array<mixed> {
 		let calendar : Array<mixed> = [];
-		const weekStartsAt : number = 1;
+		const weekStartsAt : number = this.weekStartsAtIndex;
 		const daysInPreviousMonth : number = ( 7 + this.startOfMonth.getDay() - weekStartsAt ) % 7;
 		const calendarWeeks : number = Math.ceil( ( this.daysInMonth + daysInPreviousMonth ) / 7 );
 		let currentDay : number = 1 - daysInPreviousMonth;
@@ -591,7 +596,7 @@ export default class DateTime {
 
 				weekDays.push({
 					dateTime : date,
-					isToday : this.isToday( date.getDateTime() ),
+					isToday : DateTime.isToday( date.toDate() ),
 					sameMonth
 				});
 			}


### PR DESCRIPTION
Renamed methods in DateTime.
Changed isToday to be static.